### PR TITLE
fix bug "assignment to entry in nil map cookie.go line:33"

### DIFF
--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -138,6 +138,7 @@ func (s *Server) RouteWithConfig(path string, fnc FnContent, cfg *ResponseConfig
 			kr.Server = s
 			kr.Request = r
 			kr.Writer = w
+			kr.cookies = map[string]*http.Cookie{}
 			kr.Config = rcfg
 			if int(rcfg.OutputType) == 0 {
 				if rcfg.AppName == "" {


### PR DESCRIPTION
error message:

```
2015/12/21 18:05:34 http:
goroutine 34 [running]:
net/http.(*conn).serve.func1(0xc08227cf20, 0x370ff8, 0xc0821a0070)
        c:/go/src/net/http/server.go:1287 +0xbc
github.com/eaciit/knot/knot%2ev1.(*WebContext).SetCookie(0xc0824b60f0, 0x90fd60, 0xd, 0xc0824ff020
        D:/Eaciit/src/github.com/eaciit/knot/knot.v1/cookie.go:33 +0x27b
github.com/eaciit/knot/knot%2ev1.getSessionTokenIdFromCookie(0xc0824b60f0, 0x0, 0x0)
        D:/Eaciit/src/github.com/eaciit/knot/knot.v1/session.go:54 +0x14b
github.com/eaciit/knot/knot%2ev1.(*WebContext).SetSession(0xc0824b60f0, 0x912790, 0x8, 0x7be180, 0
        D:/Eaciit/src/github.com/eaciit/knot/knot.v1/session.go:73 +0x90
eaciit/vale/knot/webapp/controllers.(*Login).Do(0xb77408, 0xc0824b60f0, 0x0, 0x0)
        D:/Eaciit/src/eaciit/vale/knot/webapp/controllers/Login.go:75 +0x73e
reflect.callMethod(0xc082053cb0, 0xc082507970)
        c:/go/src/reflect/value.go:628 +0x203
reflect.methodValueCall(0xc0824b60f0, 0xc0824b60f0, 0xc0820586c0, 0x0, 0xc0823a0f90, 0x5c73b3, 0xb
        c:/go/src/reflect/asm_amd64.s:29 +0x3d
github.com/eaciit/knot/knot%2ev1.(*Server).RouteWithConfig.func1(0x371178, 0xc08227dad0, 0xc0820d2
        D:/Eaciit/src/github.com/eaciit/knot/knot.v1/server.go:149 +0x261
net/http.HandlerFunc.ServeHTTP(0xc082005ea0, 0x371178, 0xc08227dad0, 0xc0820d2e00)
        c:/go/src/net/http/server.go:1422 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc08200adc0, 0x371178, 0xc08227dad0, 0xc0820d2e00)
        D:/Eaciit/src/github.com/gorilla/mux/mux.go:100 +0x2a5
net/http.serverHandler.ServeHTTP(0xc08200fc20, 0x371178, 0xc08227dad0, 0xc0820d2e00)
        c:/go/src/net/http/server.go:1862 +0x1a5
net/http.(*conn).serve(0xc08227cf20)
        c:/go/src/net/http/server.go:1361 +0xbf5
created by net/http.(*Server).Serve
        c:/go/src/net/http/server.go:1910 +0x3fd
```
