### PR TITLE
Shared Object on Knot

### DIFF
--- a/example/sharedobject/evening/evening.go
+++ b/example/sharedobject/evening/evening.go
@@ -1,0 +1,12 @@
+package evening
+
+import "github.com/eaciit/knot/knot.v1"
+
+type Evening struct {
+}
+
+func (h *Evening) Index(r *knot.WebContext) interface{} {
+	message := "Accessing /evening/index. There is message from /morning/index: " +
+		knot.GetSharedObject().Get("name", "").(string)
+	return message
+}

--- a/example/sharedobject/main.go
+++ b/example/sharedobject/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	. "github.com/eaciit/knot/example/sharedobject/evening"
+	. "github.com/eaciit/knot/example/sharedobject/morning"
+	"github.com/eaciit/knot/knot.v1"
+)
+
+func main() {
+	knot.DefaultOutputType = knot.OutputHtml
+	ks := new(knot.Server)
+	ks.Address = ":1234"
+	ks.Register(new(Morning), "")
+	ks.Register(new(Evening), "")
+
+	ks.Listen()
+}

--- a/example/sharedobject/morning/morning.go
+++ b/example/sharedobject/morning/morning.go
@@ -1,0 +1,12 @@
+package morning
+
+import "github.com/eaciit/knot/knot.v1"
+
+type Morning struct {
+}
+
+func (h *Morning) Index(r *knot.WebContext) interface{} {
+	knot.GetSharedObject().Set("name", "yo")
+
+	return "Accessing /morning/index"
+}

--- a/knot.v1/sharedobject.go
+++ b/knot.v1/sharedobject.go
@@ -1,0 +1,35 @@
+package knot
+
+import "sync"
+
+type SharedObject struct {
+	data map[string]interface{}
+}
+
+var instance *SharedObject
+var once sync.Once
+
+func GetSharedObject() *SharedObject {
+	once.Do(func() {
+		instance = &SharedObject{}
+		instance.data = map[string]interface{}{}
+	})
+
+	return instance
+}
+
+func (s *SharedObject) Get(key string, defaultValue interface{}) interface{} {
+	if data, isExist := s.data[key]; isExist {
+		return data
+	}
+
+	return defaultValue
+}
+
+func (s *SharedObject) Set(key string, value interface{}) {
+	s.data[key] = value
+}
+
+func (s *SharedObject) All() map[string]interface{} {
+	return s.data
+}


### PR DESCRIPTION
### Shared Object

Add new feature, shared object. this thing provide capabilities for user to store data on knot which is accessible from everywhere (application scope).

To use this just call `knot.GetSharedObject()` and then store/fetch the data
##### Set Data

```
// knot.GetSharedObject().Set("key", "value in any data type")
knot.GetSharedObject().Set("name", "batman")
```
##### Get Data

```
// knot.GetSharedObject().Get("key", "default value if null, in any data type")
knot.GetSharedObject().Get("name", "")
```
##### More Example

please see https://github.com/eaciit/knot/tree/master/example/sharedobject
