### PR TITLE
changes

### DIFF
--- a/example/sharedobject/evening/evening.go
+++ b/example/sharedobject/evening/evening.go
@@ -10,7 +10,7 @@ func (h *Evening) Index(r *knot.WebContext) interface{} {
 
 	if sharedMessage != nil {
 		message := sharedMessage.(string)
-		// or `knot.GetSharedObject().GetDefaultValue("name", "").(string)`
+		// or `knot.GetSharedObject().GetWithDefaultValue("name", "").(string)`
 
 		return "There is message from /morning/index: " + message
 	} else {

--- a/example/sharedobject/evening/evening.go
+++ b/example/sharedobject/evening/evening.go
@@ -6,7 +6,14 @@ type Evening struct {
 }
 
 func (h *Evening) Index(r *knot.WebContext) interface{} {
-	message := "Accessing /evening/index. There is message from /morning/index: " +
-		knot.GetSharedObject().Get("name", "").(string)
-	return message
+	sharedMessage := knot.GetSharedObject().Get("name")
+
+	if sharedMessage != nil {
+		message := sharedMessage.(string)
+		// or `knot.GetSharedObject().GetDefaultValue("name", "").(string)`
+
+		return "There is message from /morning/index: " + message
+	} else {
+		return "Accessing /evening/index."
+	}
 }

--- a/knot.v1/sharedobject.go
+++ b/knot.v1/sharedobject.go
@@ -18,7 +18,15 @@ func GetSharedObject() *SharedObject {
 	return instance
 }
 
-func (s *SharedObject) Get(key string, defaultValue interface{}) interface{} {
+func (s *SharedObject) Get(key string) interface{} {
+	if data, isExist := s.data[key]; isExist {
+		return data
+	}
+
+	return nil
+}
+
+func (s *SharedObject) GetWithDefaultValue(key string, defaultValue interface{}) interface{} {
 	if data, isExist := s.data[key]; isExist {
 		return data
 	}


### PR DESCRIPTION
- `Get()` only need one parameter, the key
- new method, `GetWithDefaultValue()`, required two parameters, key and default value
