### PR TITLE
fix session bug when read and/or write a new session in one process (before page even rendered)

### DIFF
--- a/knot.v1/session.go
+++ b/knot.v1/session.go
@@ -62,6 +62,7 @@ func setCookieForSession(r *WebContext, cookieId string, tokenId string, expire 
 	}
 
 	r.cookies[cookieId] = c
+	http.SetCookie(r.Writer, c)
 }
 
 func getSessionTokenIdFromCookie(r *WebContext) string {


### PR DESCRIPTION
fix session bug when read and/or write a new session in one process (before page even rendered).
many cookies will created, and it's cause a problem.

example:

r.SetSession("name", "batman")
name1 := r.Session("batman") // ---> nil
name2 := r.Session("batman") // ---> nil
