### PR TITLE
remove `gorilla/mux` library, implements golang own multiplexor instead

### DIFF
--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -16,6 +16,7 @@ type Router struct {
 
 	// map of routes, the value is pointer of interface `http.Handler`.
 	// this interface should have method `ServeHTTP(w ResponseWriter, r *Request)`
+	// this variable is not used in routing process, but used on `GetHandler()`
 	Map map[string]http.Handler
 }
 

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Router struct {
-	// implements golang multiplexor
+	// implements golang own multiplexor
 	mux *http.ServeMux
 
 	// map of routes, the value is pointer of interface `http.Handler`.

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -163,7 +163,7 @@ func (s *Server) RouteStatic(pathUrl, path string) {
 	s.Log().Info(fmt.Sprintf("Add static %s from %s", pathUrl, path))
 	fsHandler := http.StripPrefix(pathUrl, http.FileServer(http.Dir(path)))
 	// s.router().PathPrefix(pathUrl).Handler(fsHandler)
-	s.router().Handle(`/`+pathUrl+`/`, fsHandler)
+	s.router().Handle(pathUrl, fsHandler)
 }
 
 func (s *Server) Route(path string, fnc FnContent) {
@@ -230,6 +230,10 @@ func (s *Server) isReadyForSSL() bool {
 }
 
 func (s *Server) Listen() {
+	for key, _ := range s.router().Map {
+		fmt.Println(">", key)
+	}
+
 	s.start()
 	s.listen()
 }

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -17,6 +17,7 @@ type Router struct {
 	// map of routes, the value is pointer of interface `http.Handler`.
 	// this interface should have method `ServeHTTP(w ResponseWriter, r *Request)`
 	// this variable is not used in routing process, but used on `GetHandler()`
+	// because golang does not provide function to get handler using specific route
 	Map map[string]http.Handler
 }
 

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -232,10 +232,6 @@ func (s *Server) isReadyForSSL() bool {
 }
 
 func (s *Server) Listen() {
-	for key, _ := range s.router().Map {
-		fmt.Println(">", key)
-	}
-
 	s.start()
 	s.listen()
 }


### PR DESCRIPTION
- remove `gorilla/mux`
- impelments `http.ServeMux` to handle the routing
- prepare collection to store all the routes and handlers, so we could get handler information by using route in `GetHandler()` method (golang doesn't provide API to get registered handler by specific route)
