### PR TITLE
add support `/page/<page-id>`

### DIFF
--- a/example/page/main.go
+++ b/example/page/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/eaciit/knot/knot.v1"
+	"net/http"
+)
+
+func main() {
+	app := knot.NewApp("page")
+	app.Register(&PageController{})
+	knot.RegisterApp(app)
+
+	otherRoutes := map[string]knot.FnContent{
+		"/": knot.FnContent(func(r *knot.WebContext) interface{} {
+			r.Config.OutputType = knot.OutputHtml
+			return "index"
+		}),
+		"page": knot.FnContent(func(r *knot.WebContext) interface{} {
+			r.Config.OutputType = knot.OutputHtml
+			pageID := r.Request.Header.Get("PAGE_ID")
+			return pageID
+		}),
+	}
+
+	knot.StartAppWithFn(app, ":8999", otherRoutes)
+}
+
+type PageController struct {
+}
+
+func (h *PageController) Index(r *knot.WebContext) interface{} {
+	r.Config.OutputType = knot.OutputHtml
+	http.Redirect(r.Writer, r.Request, "/page/from_page_index", http.StatusTemporaryRedirect)
+	return true
+}

--- a/knot.v1/appcontainer.go
+++ b/knot.v1/appcontainer.go
@@ -138,9 +138,13 @@ func StartAppWithFn(app *App, address string, otherRoutes map[string]FnContent) 
 
 	ks.Route("/status", statusContainer)
 	ks.Route("/stop", stopContainer)
-	//ks.Route("/p", ShowPage)
 
 	for route, handler := range otherRoutes {
+		if route == "page" {
+			ks.Route("/page/{param1}/{param2}/{param3}/{param4}", handler)
+			continue
+		}
+
 		ks.Route(route, handler)
 	}
 
@@ -150,6 +154,10 @@ func StartAppWithFn(app *App, address string, otherRoutes map[string]FnContent) 
 }
 
 func StartContainer(c *AppContainerConfig) *Server {
+	return StartContainerWithFn(c, map[string]FnContent{})
+}
+
+func StartContainerWithFn(c *AppContainerConfig, otherRoutes map[string]FnContent) *Server {
 	ks := new(Server)
 	ks.Address = c.Address
 
@@ -182,7 +190,16 @@ func StartContainer(c *AppContainerConfig) *Server {
 
 	ks.Route("/status", statusContainer)
 	ks.Route("/stop", stopContainer)
-	//ks.Route("/p", ShowPage)
+
+	for route, handler := range otherRoutes {
+		if route == "page" {
+			ks.Route("/page/{param1}/{param2}/{param3}/{param4}", handler)
+			continue
+		}
+
+		ks.Route(route, handler)
+	}
+
 	ks.Listen()
 
 	return ks

--- a/knot.v1/appcontainer.go
+++ b/knot.v1/appcontainer.go
@@ -231,6 +231,7 @@ func indexContainer(indexCallback FnContent, pageCallback FnContent) FnContent {
 		// otherwise, it will be / handler
 		if regex.MatchString(rURL) {
 			args := strings.Split(strings.Replace(rURL, "/page/", "", -1), "/")
+			// the rest param after /page/ stored on header with key `PAGE_ID`
 			r.Request.Header.Set("PAGE_ID", args[0])
 			if pageCallback != nil {
 				return pageCallback(r)

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -31,7 +31,7 @@ func (r *Router) HandleFunc(pattern string, handler func(http.ResponseWriter, *h
 	// because the `routes` value must be interface `http.Handler`,
 	// we have to create some struct which contains method `ServeHTTP`,
 	// and fill the method with closure `handler` (2nd parameter)
-	r.routes[pattern] = toolkit.ToHttpHandler(handler)
+	r.routes[pattern] = http.HandlerFunc(handler)
 }
 
 func (r *Router) Handle(pattern string, handler http.Handler) {

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -18,33 +18,33 @@ type Router struct {
 	// this interface should have method `ServeHTTP(w ResponseWriter, r *Request)`
 	// this variable is not used in routing process, but used on `GetHandler()`
 	// because golang does not provide function to get handler using specific route
-	Map map[string]http.Handler
+	routes map[string]http.Handler
 }
 
 func (r *Router) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	if _, ok := r.Map[pattern]; ok {
+	if _, ok := r.routes[pattern]; ok {
 		return
 	}
 
 	r.mux.HandleFunc(pattern, handler)
 
-	// because the `Map` value must be interface `http.Handler`,
+	// because the `routes` value must be interface `http.Handler`,
 	// we have to create some struct which contains method `ServeHTTP`,
 	// and fill the method with closure `handler` (2nd parameter)
-	r.Map[pattern] = toolkit.ToHttpHandler(handler)
+	r.routes[pattern] = toolkit.ToHttpHandler(handler)
 }
 
 func (r *Router) Handle(pattern string, handler http.Handler) {
-	if _, ok := r.Map[pattern]; ok {
+	if _, ok := r.routes[pattern]; ok {
 		return
 	}
 
 	r.mux.Handle(pattern, handler)
-	r.Map[pattern] = handler
+	r.routes[pattern] = handler
 }
 
 func (r *Router) GetHandler(path string) http.Handler {
-	if val, ok := r.Map[path]; ok {
+	if val, ok := r.routes[path]; ok {
 		return val
 	} else {
 		return nil
@@ -74,7 +74,7 @@ type FnContent func(r *WebContext) interface{}
 func (s *Server) router() *Router {
 	if s.mxrouter == nil {
 		s.mxrouter = &Router{mux: http.NewServeMux()}
-		s.mxrouter.Map = map[string]http.Handler{}
+		s.mxrouter.routes = map[string]http.Handler{}
 	}
 	return s.mxrouter
 }


### PR DESCRIPTION
- knot now have 3 defined route: `/status`, `/stop`, and `/page/<page-id>`.
- if app started using `StartContainer` and `StartApp`, put the handler of the `/` and `/page/<page-id>` in `otherHandlers`
- the `<page-id>` value in `/page` is accessible from `r.Request.Header.Get("PAGE_ID")`
- create sample implementation of `/page/<page-id>` handler
