### PR TITLE
add `NoCacheUrl`, usefull for disabling cache on specific resources

### DIFF
--- a/knot.v1/writer.go
+++ b/knot.v1/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/eaciit/toolkit"
 	"html/template"
 	"io"
 	"io/ioutil"
@@ -111,6 +112,16 @@ func (r *WebContext) writeToTemplate(w io.Writer, data interface{}, templateFile
 		},
 		"UnescapeHTML": func(s string) template.HTML {
 			return template.HTML(s)
+		},
+		"NoCacheUrl": func(s string) string {
+			concatenator := "?"
+			if strings.Contains(s, "?") {
+				concatenator = `&`
+			}
+
+			randomString := toolkit.RandomString(32)
+			noCachedUrl := fmt.Sprintf("%s%snocache=%s", s, concatenator, randomString)
+			return noCachedUrl
 		},
 	}).Parse(string(bs))
 	if e != nil {


### PR DESCRIPTION
Says that we include several js files which are changed a lot on the development process.

    <script src="/static/js/layout.js"></script>
    <script src="/static/js/dashboard.js"></script>

On the dev env (or our own local machine), everything will be **OOOKKKEEEEE**. But, after we deployed the app on the production env, sometimes when we tried to access the page, it keep loaded the old js file (cached), this problem is so common, and can cause lot of problem.

Use `NoCacheUrl`, to disable the cache. Example:

    <script src="{{NoCacheUrl "/static/js/layout.js"}}"></script>
    <script src="{{NoCacheUrl "/static/js/dashboard.js"}}"></script>
    <script src="{{NoCacheUrl "/static/js/dashboard.js?arg1=a&arg2=b"}}"></script>

What happen inside the function basically just adding random string.