### PR TITLE
Fixing response not showing on /status

### DIFF
--- a/knot.v1/appcontainer.go
+++ b/knot.v1/appcontainer.go
@@ -204,6 +204,8 @@ func stopContainer(r *WebContext) interface{} {
 }
 
 func statusContainer(r *WebContext) interface{} {
+	r.Config.OutputType = OutputHtml
+
 	str := "Knot Server v1.0 (c) Eaciit"
 	return str
 }


### PR DESCRIPTION
Fixing response not showing due to wrong OutputType on /status when using StartContainer function