### PR TITLE
Fix bug unable to set multiple session data when cookies is cleared.

### DIFF
--- a/knot.v1/cookie.go
+++ b/knot.v1/cookie.go
@@ -8,20 +8,42 @@ import (
 
 var DefaultCookieExpire time.Duration
 
+func (r *WebContext) initCookies() {
+	if r.cookies == nil {
+		r.cookies = make(map[string]*http.Cookie)
+	}
+}
+
 func (r *WebContext) Cookie(name string, def string) (*http.Cookie, bool) {
-	exist := true
-	c, e := r.Request.Cookie(name)
-	if e == nil && def != "" {
+	r.initCookies()
+
+	// first search on new cookies
+	c, exist := r.cookies[name]
+
+	// when not found, try to search on request cookies
+	if exist == false {
+		var err error
+		c, err = r.Request.Cookie(name)
+		if err == nil {
+			exist = true
+		}
+	}
+
+	// when not exist and default is set
+	// put cookie with default expire time
+	if exist == false && len(def) > 0 {
 		if int(DefaultCookieExpire) == 0 {
 			DefaultCookieExpire = 30 * 24 * time.Hour
 		}
 		r.SetCookie(name, def, DefaultCookieExpire)
-		exist = false
 	}
+
 	return c, exist
 }
 
-func (r *WebContext) SetCookie(name string, value string, expiresAfter time.Duration) {
+func (r *WebContext) SetCookie(name string, value string, expiresAfter time.Duration) *http.Cookie {
+	r.initCookies()
+
 	c := &http.Cookie{}
 	c.Name = name
 	c.Value = value
@@ -31,15 +53,14 @@ func (r *WebContext) SetCookie(name string, value string, expiresAfter time.Dura
 		c.Expires = time.Now().Add(expiresAfter)
 		c.Domain = u.Host
 	}
-	if r.cookies == nil {
-		r.cookies = map[string]*http.Cookie{}
-	}
+
 	r.cookies[name] = c
+
+	return c
 }
 
 func (r *WebContext) Cookies() map[string]*http.Cookie {
-	if r.cookies == nil {
-		r.cookies = map[string]*http.Cookie{}
-	}
+	r.initCookies()
+
 	return r.cookies
 }

--- a/knot.v1/session.go
+++ b/knot.v1/session.go
@@ -1,17 +1,17 @@
 package knot
 
 import (
-	"github.com/eaciit/toolkit"
-	"net/http"
 	"sync"
 	"time"
+
+	"github.com/eaciit/toolkit"
 )
 
 type Sessions map[string]toolkit.M
 
 var (
 	sessionCookieId string
-	sessions        Sessions
+	sessions        Sessions      = make(map[string]toolkit.M)
 	sessionLocker   *sync.RWMutex = new(sync.RWMutex)
 )
 
@@ -26,17 +26,12 @@ func SessionCookieId() string {
 	return sessionCookieId
 }
 
-func InitSessions() *Sessions {
-	if sessions == nil {
-		sessions = map[string]toolkit.M{}
-	}
-	return &sessions
-}
-
 func (s Sessions) InitTokenBucket(tokenid string) {
+	sessionLocker.Lock()
 	if _, b := s[tokenid]; !b {
 		s[tokenid] = toolkit.M{}
 	}
+	sessionLocker.Unlock()
 }
 
 func (s Sessions) Set(tokenid, key string, value interface{}) {
@@ -57,39 +52,20 @@ func (s Sessions) Get(tokenid, key string, def interface{}) interface{} {
 	return value
 }
 
-/** use own cookie setter.
-using `knot.Cookie` will make cookie path follow the actual request path,
-causing returned cookie value will always different (or nil), if accessed from different page.
-because of that, fetching session value from one page to another becoming impossible */
-func setCookieForSession(r *WebContext, cookieId string, tokenId string, expire time.Duration) {
-	c := &http.Cookie{}
-	c.Name = cookieId
-	c.Value = tokenId
-	c.Expires = time.Now().Add(expire)
-	c.Path = "/"
-
-	if r.cookies == nil {
-		r.cookies = map[string]*http.Cookie{}
-	}
-
-	r.cookies[cookieId] = c
-	http.SetCookie(r.Writer, c)
-}
-
 func getSessionTokenIdFromCookie(r *WebContext) string {
-	tokenId := ""
-	c, _ := r.Cookie(SessionCookieId(), "")
-	if c == nil {
-		tokenId = toolkit.GenerateRandomString("", 32)
-		setCookieForSession(r, SessionCookieId(), tokenId, time.Hour*24*30)
-	} else {
-		tokenId = c.Value
+	c, found := r.Cookie(SessionCookieId(), "")
+	if found {
+		r.SetCookie(SessionCookieId(), c.Value, time.Hour*24*30)
+		return c.Value
 	}
+
+	tokenId := toolkit.GenerateRandomString("", 32)
+	r.SetCookie(SessionCookieId(), tokenId, time.Hour*24*30)
+
 	return tokenId
 }
 
 func (r *WebContext) Session(key string, defs ...interface{}) interface{} {
-	InitSessions()
 	tokenId := getSessionTokenIdFromCookie(r)
 	var def interface{}
 	if len(defs) > 0 {
@@ -99,7 +75,6 @@ func (r *WebContext) Session(key string, defs ...interface{}) interface{} {
 }
 
 func (r *WebContext) SetSession(key string, value interface{}) {
-	InitSessions()
 	tokenId := getSessionTokenIdFromCookie(r)
 	sessions.Set(tokenId, key, value)
 }


### PR DESCRIPTION
Session bug is triggered only when no cookies set on browser and
SetSession is called multiple times in a single request.

Bug behavior:
 1. Application ask to set session
 2. Knot searching for token cookies on request cookies
 3. Token cookies not found
 4. Knot set up random token id
 5. Go back to 1

Since searching of token cookies is only from request cookies, Knot
will forget the new set token id. As a result, multiple cookies is
set on first page load. Since token is always freshly generated,
session data is not saved at all.

We fix this by change the searching cookies using two source, the
new cookies (WebContext.cookies) and then if not found, look at
request cookies (WebContext.Request.Cookie). Now the already
generated token id will be found by WebContext.Session() code.