### PR TITLE
`server.listen()` causing CPU usage become 99% in some version of golang

### DIFF
--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -288,5 +288,15 @@ func (s *Server) Stop() {
 }
 
 func (s *Server) listen() {
-	<-s.status
+	running := true
+	for running {
+		fmt.Println("hello")
+
+		select {
+		case status := <-s.status:
+			if status == "Stop" {
+				running = false
+			}
+		}
+	}
 }

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -290,8 +290,6 @@ func (s *Server) Stop() {
 func (s *Server) listen() {
 	running := true
 	for running {
-		fmt.Println("hello")
-
 		select {
 		case status := <-s.status:
 			if status == "Stop" {

--- a/knot.v1/server.go
+++ b/knot.v1/server.go
@@ -288,16 +288,5 @@ func (s *Server) Stop() {
 }
 
 func (s *Server) listen() {
-	running := true
-	for running {
-		select {
-		case status := <-s.status:
-			if status == "Stop" {
-				running = false
-			}
-
-		default:
-			//time.Sleep(1 * time.Second)
-		}
-	}
+	<-s.status
 }


### PR DESCRIPTION
This intermittent anomaly happen when `s.listen()` is called during knot server initialization, CPU usage become 100% right after `go run`.

This problem only happen on go version `go1.8.3 darwin/amd64`, on my laptop & @sugab . It's not happening on `go1.6 windows/amd64`. Both are tested.

Basically inside the `s.listen()`, there is process to check wether channel `s.status` is retrieving value or not. This channel is used to identify state of the server, is it running or stopped.

The way we do the checking is by doing `for - select` technique, which is the best practice.

```go
func (s *Server) listen() {
    running := true
    for running {
        select {
        case status := <-s.status:
            if status == "Stop" {
                running = false
            }

        default:
            //time.Sleep(1 * time.Second)
        }
    }
}
```

The `default:` inside select are **breaking the blocking state** of `select`. It make the loop repeated. In some version of golang like `go1.8.3 darwin/amd64`, this is causing the CPU usage to be 90%. In the other version, the CPU usage looks normal.

The solution is by removing the `default:`, so the `select` state will be keep blocking, until it retrieve some value from the channel.

```go
func (s *Server) listen() {
    running := true
    for running {
        select {
        case status := <-s.status:
            if status == "Stop" {
                running = false
            }
        }
    }
}
```

### Screenshot

Before

![screen shot 2017-06-15 at 11 45 33 am](https://user-images.githubusercontent.com/982868/27166005-f83da6c2-51c1-11e7-99dc-619a17590192.png)

After changes

![screen shot 2017-06-15 at 11 46 01 am](https://user-images.githubusercontent.com/982868/27166011-011fc41e-51c2-11e7-96b4-17bd22aa712b.png)
