### PR TITLE
Create two new funcs `StartContainerWithServerAndFn` and `StartContainerWithFn`. By passing the `*knot.Server` object into the function, we'll be able to add SSL support into `knot.Start***` functions

### DIFF
--- a/knot.v1/appcontainer.go
+++ b/knot.v1/appcontainer.go
@@ -100,12 +100,19 @@ func getIncludeFiles(dirname string) []string {
 }
 
 func StartApp(app *App, address string) *Server {
-	return StartAppWithFn(app, address, map[string]FnContent{})
+	return startApp(app, address, new(Server), make(map[string]FnContent))
 }
 
 func StartAppWithFn(app *App, address string, otherRoutes map[string]FnContent) *Server {
+	return startApp(app, address, new(Server), otherRoutes)
+}
+
+func StartAppWithServerAndFn(app *App, address string, ks *Server, otherRoutes map[string]FnContent) *Server {
+	return startApp(app, address, ks, otherRoutes)
+}
+
+func startApp(app *App, address string, ks *Server, otherRoutes map[string]FnContent) *Server {
 	DefaultOutputType = app.DefaultOutputType
-	ks := new(Server)
 	ks.Address = address
 
 	//appname := app.Name
@@ -149,11 +156,18 @@ func StartAppWithFn(app *App, address string, otherRoutes map[string]FnContent) 
 }
 
 func StartContainer(c *AppContainerConfig) *Server {
-	return StartContainerWithFn(c, map[string]FnContent{})
+	return startContainer(c, new(Server), make(map[string]FnContent))
 }
 
 func StartContainerWithFn(c *AppContainerConfig, otherRoutes map[string]FnContent) *Server {
-	ks := new(Server)
+	return startContainer(c, new(Server), otherRoutes)
+}
+
+func StartContainerWithServerAndFn(c *AppContainerConfig, ks *Server, otherRoutes map[string]FnContent) *Server {
+	return startContainer(c, ks, otherRoutes)
+}
+
+func startContainer(c *AppContainerConfig, ks *Server, otherRoutes map[string]FnContent) *Server {
 	ks.Address = c.Address
 
 	for k, app := range apps {


### PR DESCRIPTION
Add two new functions: `StartAppWithServerAndFn` and `StartAppWithServerAndFn`, without breaking other similar functions.

These two functions is pretty much same with it's predecessor. The only different is, `*knot.Server` object need to be explicitly passed as argument.

### Reason

 In the previous project there is requirement to start the app with SSL support. Knot already have this capability, but it can be only achieved by doing `server.Listen()` directly from `*knot.Server` object.

The SSL cannot be implemented by using `knot.StartApp` or `knot.StartContainer`. Since the certificate & private key paths have to be passed into `*knot.Server` object, AND we don't have access into that object.

Since we cannot directly access the server object inside `knot.StartApp` and `knot.StartContainer`, I think it's better if we create function to accommodate this issue.

### Other Benefits

Other than just enabling the SSL feature, we'll get some other advantages, like: by maximizing the `*knot.Server` object we can add new routes, add static routes, etc.

### Example

##### Using `knot.StartContainerWithServerAndFn`

```go
cntnr := &knot.AppContainerConfig{
    Address: "localhost:1234",
}

ks := new(knot.Server)
ks.UseSSL = true
ks.CertificatePath = "/path/to/file"
ks.PrivateKeyPath = "/path/to/file"

otherRoutes := make(map[string]knot.FnContent)

knot.StartContainerWithServerAndFn(cntnr, ks, otherRoutes)
```

##### Using `knot.StartAppWithServerAndFn`

```go

address := "localhost:1234"

ks := new(knot.Server)
ks.UseSSL = true
ks.CertificatePath = "/path/to/file"
ks.PrivateKeyPath = "/path/to/file"

otherRoutes := make(map[string]knot.FnContent)

knot.StartAppWithServerAndFn(app, address, ks, otherRoutes)
```
